### PR TITLE
adding synonyms to exposure receptor

### DIFF
--- a/exo.obo
+++ b/exo.obo
@@ -24,8 +24,8 @@ id: ExO:0000001
 name: exposure_receptor
 namespace: exposure_receptor
 def: "An entity (e.g., a human, human population, or a human organ) that interacts with an exposure stressor during an exposure event." [CTD:curators]
-synonym: "exposure recipient" RELATED []
-synonym: "exposure target" RELATED []
+synonym: "exposure recipient" EXACT []
+synonym: "exposure target" EXACT []
 relationship: interacts_with ExO:0000000 ! exposure stressor
 created_by: cmattin
 creation_date: 2010-09-21T02:45:36Z

--- a/exo.obo
+++ b/exo.obo
@@ -24,6 +24,8 @@ id: ExO:0000001
 name: exposure_receptor
 namespace: exposure_receptor
 def: "An entity (e.g., a human, human population, or a human organ) that interacts with an exposure stressor during an exposure event." [CTD:curators]
+synonym: "exposure recipient" RELATED []
+synonym: "exposure target" RELATED []
 relationship: interacts_with ExO:0000000 ! exposure stressor
 created_by: cmattin
 creation_date: 2010-09-21T02:45:36Z


### PR DESCRIPTION
Including two related synonyms to the term exposure receptor per a request on ECTO.
https://github.com/EnvironmentOntology/environmental-exposure-ontology/issues/165

No option to select broad synonym so included 'has_related_synonym'

Hopefully this looks better @matentzn ?